### PR TITLE
Add Replace Button to Tag Selector Panel

### DIFF
--- a/public/js/app-ui/inpaint/inpaint-form.mjs
+++ b/public/js/app-ui/inpaint/inpaint-form.mjs
@@ -7,7 +7,7 @@ import { Button } from '../../custom-ui/io/button.mjs';
 import { SeedControl } from '../seed-control.mjs';
 import { createExtraInputsRenderer } from '../extra-inputs-renderer.mjs';
 import { getThemeValue } from '../../custom-ui/theme.mjs';
-import { createTagSelectionHandler, extractWordAtCursor } from '../tags/tag-insertion-util.mjs';
+import { createTagSelectionHandler, extractWordAtCursor, replaceTagInPrompt } from '../tags/tag-insertion-util.mjs';
 import { TagSelectorPanel } from '../tags/tag-selector-panel.mjs';
 import { suppressContextMenu } from '../../custom-ui/util.mjs';
 import { isTagDefinitionsLoaded } from '../tags/tag-data.mjs';
@@ -90,6 +90,13 @@ export function InpaintForm({
       (newValue) => onFieldChange('description', newValue)
     );
     handler(tagName);
+  };
+
+  // Handler for tag replacement from tag selector panel
+  const handleTagReplace = (tagName) => {
+    const currentPrompt = formState.description || '';
+    const newPrompt = replaceTagInPrompt(currentPrompt, initialSearchTerm, tagName);
+    onFieldChange('description', newPrompt);
   };
 
   // Handler to close tag panel
@@ -178,6 +185,7 @@ export function InpaintForm({
       <${TagSelectorPanel}
         isOpen=${showTagPanel}
         onSelect=${handleTagSelect}
+        onReplace=${handleTagReplace}
         onClose=${handleCloseTagPanel}
         initialSearchTerm=${initialSearchTerm}
       />

--- a/public/js/app-ui/main/generation-form.mjs
+++ b/public/js/app-ui/main/generation-form.mjs
@@ -8,7 +8,7 @@ import { ImageSelect } from '../../custom-ui/media/image-select.mjs';
 import { AudioSelect } from '../../custom-ui/media/audio-select.mjs';
 import { createExtraInputsRenderer } from '../extra-inputs-renderer.mjs';
 import { HorizontalLayout, VerticalLayout } from '../../custom-ui/themed-base.mjs';
-import { createTagSelectionHandler, extractWordAtCursor } from '../tags/tag-insertion-util.mjs';
+import { createTagSelectionHandler, extractWordAtCursor, replaceTagInPrompt } from '../tags/tag-insertion-util.mjs';
 import { TagSelectorPanel } from '../tags/tag-selector-panel.mjs';
 import { suppressContextMenu } from '../../custom-ui/util.mjs';
 import { isTagDefinitionsLoaded } from '../tags/tag-data.mjs';
@@ -82,6 +82,13 @@ export function GenerationForm({
       (newValue) => onFieldChange('description', newValue)
     );
     handler(tagName);
+  };
+
+  // Handler for tag replacement from tag selector panel
+  const handleTagReplace = (tagName) => {
+    const currentPrompt = formState.description || '';
+    const newPrompt = replaceTagInPrompt(currentPrompt, initialSearchTerm, tagName);
+    onFieldChange('description', newPrompt);
   };
 
   // Handler to close tag panel
@@ -225,6 +232,7 @@ export function GenerationForm({
       <${TagSelectorPanel}
         isOpen=${showTagPanel}
         onSelect=${handleTagSelect}
+        onReplace=${handleTagReplace}
         onClose=${handleCloseTagPanel}
         initialSearchTerm=${initialSearchTerm}
       />

--- a/public/js/app-ui/tags/tag-insertion-util.mjs
+++ b/public/js/app-ui/tags/tag-insertion-util.mjs
@@ -104,6 +104,50 @@ export function insertTagIntoPrompt(existingPrompt, tag) {
  * // Use with TagSelectorPanel
  * <TagSelectorPanel onSelect={handleTagSelect} ... />
  */
+/**
+ * Replace the first occurrence of a term in a prompt with a new tag
+ * 
+ * Normalizes both the search term and prompt text to match regardless of
+ * whether underscores or spaces are used.
+ * 
+ * @param {string} existingPrompt - The current prompt text
+ * @param {string} searchTerm - The term to replace (spaces or underscores)
+ * @param {string} newTag - The replacement tag
+ * @returns {string} The prompt with the first matching occurrence replaced
+ * 
+ * @example
+ * replaceTagInPrompt('girl, blue_eyes, hair', 'blue eyes', 'red_eyes') // Returns: 'girl, red_eyes, hair'
+ */
+export function replaceTagInPrompt(existingPrompt, searchTerm, newTag) {
+  if (!existingPrompt || !searchTerm) {
+    return existingPrompt;
+  }
+
+  // Normalize: try to match with both spaces and underscores treated as equivalent
+  const normalizedSearch = searchTerm.trim().replace(/_/g, ' ');
+  const normalizedSearchUnderscore = searchTerm.trim().replace(/\s+/g, '_');
+
+  // Try matching with spaces first, then underscores
+  const spacePattern = new RegExp(
+    '(?<![\\w])' + normalizedSearch.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(?![\\w])',
+    'i'
+  );
+  const underscorePattern = new RegExp(
+    '(?<![\\w])' + normalizedSearchUnderscore.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(?![\\w])',
+    'i'
+  );
+
+  if (spacePattern.test(existingPrompt)) {
+    return existingPrompt.replace(spacePattern, newTag);
+  }
+  if (underscorePattern.test(existingPrompt)) {
+    return existingPrompt.replace(underscorePattern, newTag);
+  }
+
+  // If no match found, fall back to inserting
+  return insertTagIntoPrompt(existingPrompt, newTag);
+}
+
 export function createTagSelectionHandler(getCurrentValue, setValue, onClose) {
   return (tagName) => {
     // Get current prompt value

--- a/public/js/app-ui/tags/tag-selector-panel.mjs
+++ b/public/js/app-ui/tags/tag-selector-panel.mjs
@@ -123,6 +123,7 @@ FooterSection.className = 'tag-selector-panel-footer-section';
  * @param {Function} props.onSelect - Callback when a tag is selected: (tagName) => void
  * @param {Function} props.onClose - Callback when modal should close: () => void
  * @param {string} [props.initialSearchTerm] - Optional initial search term to navigate to when opening
+ * @param {Function} [props.onReplace] - Optional callback when a tag replaces the initial search term: (tagName) => void
  * @returns {preact.VNode}
  * 
  * @example
@@ -640,20 +641,40 @@ export class TagSelectorPanel extends Component {
   }
 
   /**
+   * Get the tag name for the current node
+   * @returns {string}
+   */
+  getCurrentTagName() {
+    const { currentNode } = this.state;
+    return currentNode.replace(/^tag_groups?:?\/*/i, '').replace(/.*\//, '').replace(/_/g, ' ');
+  }
+
+  /**
    * Handle tag insertion
    */
   handleInsert = () => {
-    const { currentNode } = this.state;
     const { onSelect } = this.props;
     
-    // Get the tag name without any prefix or path
-    const tagName = currentNode.replace(/^tag_groups?:?\/*/i, '').replace(/.*\//, '').replace(/_/g, ' ');
-    
     if (onSelect) {
-      onSelect(tagName);
+      onSelect(this.getCurrentTagName());
     }
     
     // Don't close the modal - user can continue selecting tags
+  }
+
+  /**
+   * Handle tag replacement (replaces the initial search term in the prompt)
+   */
+  handleReplace = () => {
+    const { onReplace, onClose } = this.props;
+    
+    if (onReplace) {
+      onReplace(this.getCurrentTagName());
+    }
+    
+    if (onClose) {
+      onClose();
+    }
   }
 
   render() {
@@ -824,7 +845,9 @@ export class TagSelectorPanel extends Component {
 
   renderFooter() {
     const { theme, currentNode } = this.state;
+    const { initialSearchTerm } = this.props;
     const currentDefinition = getTagDefinition(currentNode);
+    const hasInitialTerm = !!(initialSearchTerm && initialSearchTerm.trim());
     
     return html`
       <${FooterSection}
@@ -839,6 +862,14 @@ export class TagSelectorPanel extends Component {
           onClick=${this.handleInsert}
         >
           Insert
+        </${Button}>
+        <${Button}
+          variant="medium-text"
+          color="primary"
+          disabled=${!currentDefinition || !hasInitialTerm}
+          onClick=${this.handleReplace}
+        >
+          Replace
         </${Button}>
       </${FooterSection}>
     `;


### PR DESCRIPTION
Adds a Replace button to the tag selector panel that is enabled when the panel is opened with an initial search term (e.g. via right-click on a word in the prompt). Clicking Replace substitutes the first occurrence of the initial search term in the prompt with the currently selected tag, then closes the panel. A `replaceTagInPrompt` utility was added to `tag-insertion-util.mjs` to handle space/underscore-normalized matching, and both `generation-form.mjs` and `inpaint-form.mjs` were updated to wire up the new `onReplace` callback.